### PR TITLE
Add a more descriptive legend title

### DIFF
--- a/src/components/Filter.js
+++ b/src/components/Filter.js
@@ -79,7 +79,7 @@ const Filter = ({
       </div>
       {currentFilters.color && (
         <div className="filter-key">
-          <h4>Map Key by Percentile</h4>
+          <h4>Ratio of actual to scheduled trips<br></br>Percentile rank</h4>
           <ul>
             <li>
               <span className="percentile-text">0-19%</span>


### PR DESCRIPTION
There was some feedback about the map legend being somewhat [confusing](https://docs.google.com/document/d/1vaJw82cp9ER792PzO1cVDznqI86dCMR6DlJzAddBL8s/edit#). This will hopefully explain the map key better. Adding in @lauriemerrell