### PR TITLE
Addressed content resize every time bus animation restarted

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -966,6 +966,13 @@ footer .footer-container ul li a:hover, footer .footer-container ul li a:focus {
     align-items: flex-start;
   }
 }
+html,
+body {
+  width: 100%;
+  max-width: 100%;
+  overflow-x: hidden;
+}
+
 body {
   line-height: 1.6;
 }

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -13,6 +13,13 @@
 @import "bus-route-details";
 @import "footer";
 
+html,
+body {
+  width: 100%;
+  max-width: 100%;
+  overflow-x: hidden;
+}
+
 body {
   line-height: 1.6;
 }


### PR DESCRIPTION
Set the `width` and `max-width` of `html` and `body` to 100% and `overflow-x: hidden`.