### PR TITLE
Simultaneously show top and bottom 10 buses when both checkboxes are selected

### DIFF
--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -35,9 +35,13 @@ export default function Map() {
       !currentFilters.reliability.top10 || route.properties.ranking <= 10;
     const bottomTen =
       !currentFilters.reliability.bottom10 || route.properties.ranking >= 114;
-    return topTen && bottomTen;
-  };
 
+    if (currentFilters.reliability.top10 && currentFilters.reliability.bottom10){
+        return topTen || bottomTen;
+    } else {
+        return topTen && bottomTen;
+    }
+  };
   const availableRoutes = resultsData.features
     .filter(filterMapRoutes)
     .map((route) => route.properties.route_id)


### PR DESCRIPTION
**Overview**
This change enables users to toggle top and bottom 10 buses simultaneously. 

**Problem**
If you click "Top 10" and "Bottom 10" on the filter menu, instead of showing both sets of routes it shows none of them.

**Solution**
Update the logic in `map.js` so that we no longer assume there will be only one of the boxes checked at a time. Account for situations with multiple checked boxes.