### PR TITLE
fix(_filters.scss): change filter icon color to cta-blue 

### DIFF
--- a/src/scss/_filters.scss
+++ b/src/scss/_filters.scss
@@ -8,6 +8,7 @@
     @include flex-center;
     padding: 10px;
     background-color: white;
+    color: $cta-blue;
     border-radius: 10px;
     cursor: pointer;
   }


### PR DESCRIPTION
<!-- Note: please make sure to assign a project maintainer to your open PR for review!-->
Project maintainer: @amy-corson 

## Description
<!-- Please describe the purpose of this PR. Be sure to link to any existing issues that this PR seeks to address. If you are adding dependencies, please outline the purpose & link to their docs.  -->
This pull request fixes the issue raised [here](https://github.com/chihacknight/ghost-buses-frontend/issues/71).


## Checklist <!-- Please delete any that do not apply to your PR -->
- [x] I am requesting to merge into the dev branch <!-- We commit changes to dev for initial QA testing before we deploy to production -->
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Screenshots

<!-- If this is a UI change, please add screenshots of your change in the table below -->

Before:
<img width="714" alt="Screen Shot 2023-05-10 at 6 36 59 PM" src="https://github.com/chihacknight/ghost-buses-frontend/assets/58137284/9ab34062-91c0-472f-bf99-516ea213f51c">

After:
<img width="717" alt="Screen Shot 2023-05-10 at 6 36 18 PM" src="https://github.com/chihacknight/ghost-buses-frontend/assets/58137284/ac7bd781-8220-41da-a5f7-2b82151bb497">
