### PR TITLE
feat(_page.scss): remove underline for zoom in and out button on hover

### DIFF
--- a/src/scss/_page.scss
+++ b/src/scss/_page.scss
@@ -7,7 +7,8 @@
     text-decoration: none;
     font-weight: 700;
 
-    &:hover, &:focus {
+   
+    &:not(.leaflet-control-zoom-in):not(.leaflet-control-zoom-out):hover, &:not(.leaflet-control-zoom-in):not(.leaflet-control-zoom-out):focus {
       color: $blue-button;
       text-decoration: underline;
     }


### PR DESCRIPTION
<!-- Hello! Thank you for contributing to our project. Please see our README for detailed instructions on how to contribute. -->

<!-- Note: please make sure to assign a project maintainer to your open PR for review!-->
Project maintainer: @amy-corson 

## Description
<!-- Please describe the purpose of this PR. Be sure to link to any existing issues that this PR seeks to address. If you are adding dependencies, please outline the purpose & link to their docs.  -->
This pull request prevents the zoom-in and zoom-out button icons from underlining when the user hovers their mouse over the buttons. This addresses the issue found [here](https://github.com/chihacknight/ghost-buses-frontend/issues/70).


## Checklist <!-- Please delete any that do not apply to your PR -->
- [x] I am requesting to merge into the dev branch <!-- We commit changes to dev for initial QA testing before we deploy to production -->
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Screenshots

<!-- If this is a UI change, please add screenshots of your change in the table below -->
Before:
![original_zoom_in_out](https://github.com/chihacknight/ghost-buses-frontend/assets/58137284/789e715d-ef3a-4cae-a8ae-4885d3ad4af8)

After:
<img width="97" alt="Screen Shot 2023-05-15 at 4 12 44 PM" src="https://github.com/chihacknight/ghost-buses-frontend/assets/58137284/e6cd900b-4ef2-4830-a86d-63688e7f57d9">


