### PR TITLE
Update route highlight to bring highlighted route to top

### DIFF
--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -179,6 +179,7 @@ export default function Map() {
       color: "#fff",
       fillOpacity: 1,
     });
+    layer.bringToFront();
   }
 
   function resetHighlight(e) {


### PR DESCRIPTION
This pr is to merge the one change I made to components/map.js into the dev branch. This change was to add code to bring the highlighted route to the forefront so it was not hidden by other routes.

I decided the easiest, fastest way to implement this request was to use the layer.bringToFront() function on the route's path. Since there didn't seem to be any layer order in the way the routes were layered on the map, I decided there was no corresponding action which needed to be taken when the route was no longer highlighted. Therefore, it will remain at the top of the route stack, but it will return to the original color.


## Checklist <!-- Please delete any that do not apply to your PR -->
- [x] I am requesting to merge into the main branch 
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas


## Screenshots
![253429156-2eef0ac5-a5f7-45be-a9db-8e34055ffabc](https://github.com/chihacknight/ghost-buses-frontend/assets/28713997/eccc025d-9be3-4185-bf03-81df4129c56f)



Upon merging, this issue #39 should be closed.
