### PR TITLE
new block quote fix

### DIFF
--- a/src/scss/_block-quote.scss
+++ b/src/scss/_block-quote.scss
@@ -4,7 +4,7 @@
   width: 60%;
   margin: 2em 0;
   padding-left: 1em;
-  text-align: right;
+  text-align: left;
 
   p {
     font-size: 1rem;


### PR DESCRIPTION
This will change the alignment of the block quote on the home page from right to left as requested in issue #47.  Upon being merged this will close issue #47 

## Checklist <!-- Please delete any that do not apply to your PR -->
- [ ] I am requesting to merge into the main branch 
- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings

## Screenshots
Before:
![before](https://github.com/chihacknight/ghost-buses-frontend/assets/28713997/9dd88bb3-634a-4ce8-9d6b-0fd8e53aec33)

After:
![after](https://github.com/chihacknight/ghost-buses-frontend/assets/28713997/6c05820f-df24-4afd-9165-902d02c57351)

