### PR TITLE
fix: add aria-label to <a> elements

### DIFF
--- a/src/Pages/InteractiveMap.js
+++ b/src/Pages/InteractiveMap.js
@@ -54,6 +54,7 @@ const InteractiveMap = () => {
           href="https://github.com/chihacknight/breakout-groups/issues/217"
           target="_blank"
           rel="noreferrer"
+          aria-label="Breakout group information link"
         >
           <button className="action-btn">Breakout group information</button>
         </a>
@@ -61,6 +62,7 @@ const InteractiveMap = () => {
           href="https://github.com/chihacknight/ghost-buses-frontend"
           target="_blank"
           rel="noreferrer"
+          aria-label="Frontend Repository link"
         >
           <button className="action-btn">Frontend Repository</button>
         </a>
@@ -68,6 +70,7 @@ const InteractiveMap = () => {
           href="https://github.com/chihacknight/chn-ghost-buses/"
           target="_blank"
           rel="noreferrer"
+          aria-label="Data Repository link"
         >
           <button className="action-btn">Data Repository</button>
         </a>
@@ -75,6 +78,7 @@ const InteractiveMap = () => {
           href="https://twitter.com/ghostbuses"
           target="_blank"
           rel="noreferrer"
+          aria-label="Ghost Buses Twitter link"
         >
           <button className="action-btn">Ghost Bus Twitter</button>
         </a>

--- a/src/components/Socials.js
+++ b/src/components/Socials.js
@@ -1,20 +1,28 @@
 import React from "react";
 
-
 export default function Socials() {
   return (
     <div className="social-sidebar">
-      <a href="https://twitter.com/ghostbuses">
+      <a
+        href="https://twitter.com/ghostbuses"
+        aria-label="Ghost Buses Twitter link"
+      >
         <div className="social-icon twitter">
           <i className="fa-brands fa-twitter"></i>
         </div>
       </a>
-      <a href="https://github.com/chihacknight/chn-ghost-buses">
+      <a
+        href="https://github.com/chihacknight/chn-ghost-buses"
+        aria-label="Ghost Buses GitHub link"
+      >
         <div className="social-icon github">
           <i className="fa-brands fa-github"></i>
         </div>
       </a>
-      <a href="https://chihacknight.org/">
+      <a
+        href="https://chihacknight.org/"
+        aria-label="Chi Hack Night website link"
+      >
         <div className="social-icon chn">
           <svg
             version="1.0"


### PR DESCRIPTION

## Description
This PR is being opened to merge into dev branch. This fixes the links without a discernible text. I added aria-label attributes.

It will close the issue https://github.com/chihacknight/ghost-buses-frontend/issues/90, when approved.

## Checklist
- [x] I am requesting to merge into the main branch
- [x] I have performed a self-review of my code

## Screenshots
<img width="922" alt="Screenshot of light house test" src="https://github.com/chihacknight/ghost-buses-frontend/assets/103542032/8e5ac629-37b4-4e64-89f1-bf9d1690ced4">

This is a screenshot of the Lighthouse Test.
