### PR TITLE
fix : disable zoom when double click on containers

### DIFF
--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -202,23 +202,22 @@ export default function Map() {
       {selectedRoute && (
         <Modal selectedRoute={selectedRoute} closeModal={closeModal} />
       )}
+      <Filter
+        filterOpen={filterOpen}
+        setFilterOpen={setFilterOpen}
+        currentFilters={currentFilters}
+        setCurrentFilters={setCurrentFilters}
+      />
+      <Search
+        onChangeSearch={onChangeSearch}
+        searchTerm={searchTerm}
+        searchResultsElements={searchResultsElements}
+      />
       <MapContainer
         center={[41.881832, -87.691916]}
         zoom={11}
         scrollWheelZoom={false}
       >
-        <Filter
-          filterOpen={filterOpen}
-          setFilterOpen={setFilterOpen}
-          currentFilters={currentFilters}
-          setCurrentFilters={setCurrentFilters}
-        />
-        <Search
-          onChangeSearch={onChangeSearch}
-          searchTerm={searchTerm}
-          searchResultsElements={searchResultsElements}
-        />
-
         <TileLayer
           attribution='&copy; <a href="https://stadiamaps.com/">Stadia Maps</a>, &copy; <a href="https://openmaptiles.org/">OpenMapTiles</a> &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors'
           url="https://tiles.stadiamaps.com/tiles/alidade_smooth_dark/{z}/{x}/{y}{r}.png"

--- a/src/scss/_map.scss
+++ b/src/scss/_map.scss
@@ -5,7 +5,7 @@
   .search-container {
       position: absolute;
       right: 15px;
-      top: 15px;
+      top: 40px;
       z-index: 150;
   }
 }

--- a/src/scss/_modal.scss
+++ b/src/scss/_modal.scss
@@ -6,7 +6,7 @@
     width: 100%;
     height: 100%;
     background: rgba(0, 0, 0, 0.4);
-    z-index: 100;
+    z-index: 200;
     font-family: $modal-font;
     letter-spacing: -1px;
   


### PR DESCRIPTION
## Description

This will close issue #46, when approved. I put `Filter` and `Search` component out of `Map Container` in order to disable zoom when users double click the UI.

## Checklist <!-- Please delete any that do not apply to your PR -->
- [x] I am requesting to merge into the main branch
- [x] I have performed a self-review of my code