### PR TITLE
feat(94): focus() modal close button on open

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -88,7 +88,7 @@ export default function Modal({ selectedRoute, closeModal, }) {
 
   const busFraction = calcBusFraction(totalAcc.toFixed(0))
   return (
-    <div className="modal" onClick={closeModal} >
+    <div className="modal" onClick={closeModal}>
       <div className="modal-container" onClick={(e) => e.stopPropagation()}>
         <button onClick={closeModal} ref={modalCloseRef} className="close-btn" aria-label="Close">
           x

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -1,7 +1,6 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import BusRouteDetails from "./BusRouteDetails";
 import { Link } from "react-router-dom";
-import { useRef } from "react";
 
 export default function Modal({ selectedRoute, closeModal, }) {
   const modalCloseRef = useRef(null);

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -1,10 +1,15 @@
-import React from "react";
+import React, { useEffect } from "react";
 import BusRouteDetails from "./BusRouteDetails";
 import { Link } from "react-router-dom";
+import { useRef } from "react";
 
 export default function Modal({ selectedRoute, closeModal, }) {
+  const modalCloseRef = useRef(null);
 
-
+  useEffect(() => {
+    const modalCloseBtn = modalCloseRef.current;
+    if (modalCloseBtn) modalCloseBtn.focus();
+  }, [modalCloseRef]);
 
   // take all the ratios from the data and average out each line's mean bus reliablility
 
@@ -84,9 +89,9 @@ export default function Modal({ selectedRoute, closeModal, }) {
 
   const busFraction = calcBusFraction(totalAcc.toFixed(0))
   return (
-    <div className="modal" onClick={closeModal}>
+    <div className="modal" onClick={closeModal} >
       <div className="modal-container" onClick={(e) => e.stopPropagation()}>
-        <button onClick={closeModal} className="close-btn">
+        <button onClick={closeModal} ref={modalCloseRef} className="close-btn" aria-label="Close">
           x
         </button>
         <BusRouteDetails

--- a/src/scss/_modal.scss
+++ b/src/scss/_modal.scss
@@ -32,6 +32,8 @@
         cursor: pointer;
         border-radius: 50%;
         padding: 1em;
+        height: 3.25em;
+        width: 3.25em;
         @include transitionHover;
   
         &:hover {


### PR DESCRIPTION
## Description
Small a11y enhancement for https://github.com/chihacknight/ghost-buses-frontend/issues/94 to `focus()` the modal close button when opened. In addition, ensures the close button is perfectly circular.

## Checklist
- [x] I am requesting to merge into the dev branch <!-- We commit changes to dev for initial QA testing before we deploy to production -->
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots

| Before      | After       |
| ----------- | ----------- |
| ![image](https://github.com/chihacknight/ghost-buses-frontend/assets/16638739/2ba8c92f-62a9-4e7e-bfc8-453613b7f5fc) |  ![image](https://github.com/chihacknight/ghost-buses-frontend/assets/16638739/2325f356-f77e-46a9-9627-327bb38bdd8e) |
