### PR TITLE
fix(101) unify the display of the bus summary stats that appear in th…

### DIFF
--- a/src/Pages/RouteStats.js
+++ b/src/Pages/RouteStats.js
@@ -1,5 +1,5 @@
-import { useResults } from  "../components/Context.js"
-import { useRidership } from "../components/Context.js"
+import { useResults } from "../components/Context.js";
+import { useRidership } from "../components/Context.js";
 import React, { useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import findPercentileIndex from "../utils/percentileKeys";
@@ -10,23 +10,21 @@ import GhostingGraphic from "../components/stat-visuals/GhostingGraphic";
 import ReliabilityRankGraphic from "../components/stat-visuals/ReliabilityRankGraphic";
 import PercentileGraphic from "../components/stat-visuals/PercentileGraphic";
 import TripRatioGraph from "../components/stat-visuals/TripRatioGraph";
-
-
-
+import BusRouteDetails from "../components/BusRouteDetails.js";
 
 //copy-pasted from modal component; need to refactor
 const calcBusFraction = (acc) => {
-  let fraction
+  let fraction;
   if (acc > 22 && acc < 27) {
-    fraction = [3, 4]
+    fraction = [3, 4];
   } else if (acc > 72 && acc < 77) {
-    fraction = [1, 4]
+    fraction = [1, 4];
   } else {
-    fraction = reduce((100 - round10(Math.round(acc))), 100);
+    fraction = reduce(100 - round10(Math.round(acc)), 100);
   }
 
-  return fraction
-}
+  return fraction;
+};
 
 function round10(x) {
   let digits = x.toString().split("");
@@ -47,14 +45,9 @@ function reduce(numerator, denominator) {
   return [numerator / gcd, denominator / gcd];
 }
 
-
-
-const RouteStats = () => {  
+const RouteStats = () => {
   const { resultsData } = useResults();
   const { ridershipData } = useRidership();
-
-
-  
 
   // Search functions (need to be refactored)
   const [searchTerm, setSearchTerm] = useState("");
@@ -79,13 +72,17 @@ const RouteStats = () => {
     })
     .filter((route) => {
       return route.properties.day_type === "wk";
-    });;
+    });
 
   const searchResultsElements = searchResults.map((result) => (
     <div
       key={result.properties.route_id}
       className="search-result"
-      onClick={() => navigate('/route-stats/' + result.properties.route_id, { replace: true })}
+      onClick={() =>
+        navigate("/route-stats/" + result.properties.route_id, {
+          replace: true,
+        })
+      }
     >
       <p>
         <span>{result.properties.route_id}</span>
@@ -96,17 +93,13 @@ const RouteStats = () => {
 
   // End of search code
 
-
-
   let { route } = useParams();
-
-
 
   let selectedRoute = resultsData.features.filter(
     (data) => String(data.properties.route_id) === route
-  )
-  const totalAcc = (selectedRoute[0].properties.ratio) * 100;
-  const busFraction = calcBusFraction(totalAcc.toFixed(0))
+  );
+  const totalAcc = selectedRoute[0].properties.ratio * 100;
+  const busFraction = calcBusFraction(totalAcc.toFixed(0));
 
   const selectedRouteRidership = ridershipData.filter(
     (x) => x.route_id === selectedRoute[0].properties.route_id
@@ -126,9 +119,7 @@ const RouteStats = () => {
             {selectedRoute[0].properties.route_id}
           </span>{" "}
         </h1>
-        <h2>
-          {selectedRoute[0].properties.route_long_name}
-        </h2>
+        <h2>{selectedRoute[0].properties.route_long_name}</h2>
         <Search
           onChangeSearch={onChangeSearch}
           searchTerm={searchTerm}
@@ -136,23 +127,28 @@ const RouteStats = () => {
         />
       </div>
 
-      <div className="stats-list">
-
+      <div>
         {/* TO DO: Add static map zoomed in on route. Grab route map off CTA website? */}
-        
-        <TripRatioGraph 
-          route_id={selectedRoute[0].properties.route_id}/>
 
-        <RidershipGraphic
-          ridershipCount={averageRidershipPerWeekday.avg_riders}
-          intervalName="weekday" />
-
-        <PercentileGraphic percentileIndex={percentileIndex} />
-
-        <GhostingGraphic busFraction={busFraction} />
-
-        <ReliabilityRankGraphic rank={selectedRoute[0].properties.ratio_ranking} />
-
+        <TripRatioGraph route_id={selectedRoute[0].properties.route_id} />
+        <h2 style={{ textAlign: "center" }}>Route stats</h2>
+        <div className="bus-route-details">
+          <div className='flex-center'>
+            <RidershipGraphic
+              ridershipCount={averageRidershipPerWeekday.avg_riders}
+              intervalName="weekday"
+            />
+          </div>
+          <div className="percentile">
+            <PercentileGraphic percentileIndex={percentileIndex} />
+          </div>
+          <GhostingGraphic busFraction={busFraction} />
+          <div className="fraction">
+            <ReliabilityRankGraphic
+              rank={selectedRoute[0].properties.ratio_ranking}
+            />
+          </div>{" "}
+        </div>
       </div>
 
       <p className="footnote">
@@ -165,8 +161,7 @@ const RouteStats = () => {
           CTA Ridership Report
         </a>{" "}
       </p>
-
-    </div >
+    </div>
   );
 };
 

--- a/src/components/BusRouteDetails.js
+++ b/src/components/BusRouteDetails.js
@@ -21,30 +21,30 @@ function BusRouteDetails({ selectedRoute, busFraction }) {
   const percentileIndex = findPercentileIndex(selectedRoute[0]);
 
   return (
-    <div className="bus-route-details">
+    <div>
       <h3>
         <span className="bus-number">
           {selectedRoute[0].properties.route_id}
         </span>{" "}
         {selectedRoute[0].properties.route_long_name}
       </h3>
-      <div className="grid">
+      <div className="bus-route-details">
 
-        <div className="grid-square ridership">
+        <div className='flex-center'>
           <RidershipGraphic
             ridershipCount={averageRidershipPerWeekday.avg_riders}
             intervalName="weekday" />
         </div>
 
-        <div className="grid-square percentile">
+        <div className="percentile">
           <PercentileGraphic percentileIndex={percentileIndex} />
         </div>
 
-        <div className="grid-square bus-graphic">
+        <div>
           <GhostingGraphic busFraction={busFraction} />
         </div>
 
-        <div className="grid-square fraction">
+        <div className="fraction">
           <ReliabilityRankGraphic rank={selectedRoute[0].properties.ratio_ranking} />
         </div>
 

--- a/src/components/Filter.js
+++ b/src/components/Filter.js
@@ -74,7 +74,7 @@ const Filter = ({
           onClick={() => setFilterOpen((prevFilterOpen) => !prevFilterOpen)}
           aria-label="Open map filtering options"
         >
-          <i aria-hidden="true" class="fa-solid fa-filter"></i>
+          <i aria-hidden="true" className="fa-solid fa-filter"></i>
         </button>
       </div>
       {currentFilters.color && (

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -27,8 +27,8 @@ export default function Header() {
         <img src={bus} alt="" />
       </div>
       <button onClick={() => setPauseAnimation(prevPauseAnimation => !prevPauseAnimation)}  aria-label="pause/play bus animation" title="pause/play bus animation" >
-        {!pauseAnimation && <i class="fa-solid fa-pause"></i>}
-        {pauseAnimation && <i class="fa-solid fa-play"></i>}
+        {!pauseAnimation && <i className="fa-solid fa-pause"></i>}
+        {pauseAnimation && <i className="fa-solid fa-play"></i>}
       </button>
     </header>
   );

--- a/src/components/stat-visuals/GhostingGraphic.js
+++ b/src/components/stat-visuals/GhostingGraphic.js
@@ -16,12 +16,12 @@ function GhostingGraphic({ busFraction }) {
                         </p>
                     </div>
                     <div className="bus-ghost-container">
-                        {[...Array(busFraction[1] - busFraction[0])].map((x) => (
-                            <img src={busIcon} alt="representation of CTA bus" />
+                        {[...Array(busFraction[1] - busFraction[0])].map((x, i) => (
+                            <img key={`ghost-${i}`} src={busIcon} alt="representation of CTA bus" />
                         ))}
 
-                        {[...Array(busFraction[0])].map((x) => (
-                            <img src={ghostIcon} alt="representation of CTA bus" />
+                        {[...Array(busFraction[0])].map((x, i) => (
+                            <img key={`ghost-${i}`} src={ghostIcon} alt="representation of CTA bus" />
                         ))}
                     </div>
                 </div>

--- a/src/scss/_bus-route-details.scss
+++ b/src/scss/_bus-route-details.scss
@@ -1,14 +1,14 @@
 .bus-route-details {
-  .grid {
-    display: grid;
-    grid-template-columns: 1fr;
+    display: flex;
     align-items: center;
     justify-content: center;
+    flex-wrap: wrap;
 
-    div.grid-square {
+    > div {
+      border-bottom: 1px $text-color solid;
+      flex: 40%;
       height: 200px;
       padding: 4em 2em;
-      align-content: center;
       
       &.percentile {
         @include flex-center;
@@ -18,15 +18,13 @@
       }
       
     }
-  }
 }
 
-@media (min-width: $desktop-bp) {
+@media (min-width: 650px) {
   .bus-route-details {
-    .grid {
-      grid-template-columns: 1fr 1fr;
 
-      div.grid-square {
+      > div {
+        border-bottom: none;
         padding: 2em;
         &:first-child {
           border-right: 1px $text-color solid;
@@ -40,5 +38,4 @@
         }
       }
     }
-  }
 }

--- a/src/scss/_route-stats.scss
+++ b/src/scss/_route-stats.scss
@@ -14,22 +14,6 @@
     }
 }
 
-.stats-list {
-
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 15vh;
-    padding-top: 10vh;
-    padding-bottom: 10vh;
-
-    * {
-        flex: 1 auto;
-        margin: 5px;
-    }
-
-}
-
 .footnote {
     font-weight: 400;
     font-size: 12px;

--- a/src/scss/_stat-visuals.scss
+++ b/src/scss/_stat-visuals.scss
@@ -83,25 +83,21 @@
     }
   }
 
-  .bus-ghost-container {
-    border: 0;
-    padding: 0;
-    margin-top: 2em;
-    display: grid;
-    grid-template-columns: repeat(auto-fit, 40px);
-    grid-auto-rows: 1fr min-content;
-    grid-gap: 5px;
-    align-items: center;
-    justify-items: center;
-    justify-content: center;
+}
 
-    img {
-      width: 30px;
-      align-self: center;
-      padding: 7px 0;
-    }
+.bus-ghost-container {
+  border: 0 ;
+  padding: 0 40px;
+  margin-top: 1em;
+  display: flex;
+  align-items: center;
+  justify-content: center ;
+  flex-wrap: wrap;
+  img {
+    align-self: center;
+    padding: 7px 0;
+    width: 30px
   }
-
 }
 
 .trip-performance-graph {

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -124,4 +124,6 @@ code {
   }
 }
 
-
+.flex-center {
+  @include flex-center;
+}


### PR DESCRIPTION
unify the display of the bus summary stats that appear in the modal and on the route-stats page; clean up some console errors; formatting fixes

<!-- Hello! Thank you for contributing to our project. Please see our README for detailed instructions on how to contribute. -->

<!-- Note: please make sure to assign a project maintainer to your open PR for review!-->

## Description
<!-- Please describe the purpose of this PR. Be sure to link to any existing issues that this PR seeks to address. If you are adding dependencies, please outline the purpose & link to their docs.  -->
This PR does the following:
 - some formatting fixes from running prettier on a few files (didn't touch many of those lines of code
 - fixed some console errors from using class instead of classname and from not having a key on dom elements that were mapped over
 - converted some of the styling to use flex mostly bc I think it's easier to use
 - unified the styling of the modal and the route-stats page. I think the modal layout looks good on the route-stats page so I made them the same

## Checklist <!-- Please delete any that do not apply to your PR -->
- [ ] I am requesting to merge into the dev branch <!-- We commit changes to dev for initial QA testing before we deploy to production -->
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Screenshots

<!-- If this is a UI change, please add screenshots of your change in the table below -->

| Before      | After       |
| -------
---- | ----------- |
| <img width="703" alt="Screenshot 2023-12-28 at 5 54 03 PM" src="https://github.com/chihacknight/ghost-buses-frontend/assets/110838171/1affce0f-6f9a-4bc1-a1c9-2f2db3702f3e">      |   
<img width="638" alt="Screenshot 2023-12-28 at 5 53 36 PM" src="https://github.com/chihacknight/ghost-buses-frontend/assets/110838171/ed368b4b-1959-4838-bdab-11932565b4b0">
   |
|  
<img width="514" alt="Screenshot 2023-12-28 at 5 54 52 PM" src="https://github.com/chihacknight/ghost-buses-frontend/assets/110838171/6074a6b3-782c-4e0a-af04-aab94425e811">
   |  
<img width="638" alt="Screenshot 2023-12-28 at 5 53 36 PM" src="https://github.com/chihacknight/ghost-buses-frontend/assets/110838171/c413c8ac-cafc-4a4d-aac2-ad442e1640e2">
  |