### PR TITLE
Change y-axis on trip ratio plot to autoscale

### DIFF
--- a/src/components/stat-visuals/TripRatioGraph.js
+++ b/src/components/stat-visuals/TripRatioGraph.js
@@ -196,7 +196,7 @@ function TripRatioGraph({ route_id }) {
         title: 'Schedule Attainment',
         yaxis: {
             title: 'Ratio of Actual vs. Scheduled Trips',
-            range: [0.0, 1.2],
+            autorange: true,
             zeroline: false
         },
         annotations: [
@@ -222,7 +222,7 @@ function TripRatioGraph({ route_id }) {
             }
         ]
     };
-
+    
     return (
         <div className="trip-performance-graph">
 


### PR DESCRIPTION
<!-- Hello! Thank you for contributing to our project. Please see our README for detailed instructions on how to contribute. -->

<!-- Note: please make sure to assign a project maintainer to your open PR for review!-->

## Description
<!-- Please describe the purpose of this PR. Be sure to link to any existing issues that this PR seeks to address. If you are adding dependencies, please outline the purpose & link to their docs.  -->
Autoscale y-axis on ratio plot. Fixes #127.


## Checklist <!-- Please delete any that do not apply to your PR -->
- [ ] I am requesting to merge into the dev branch <!-- We commit changes to dev for initial QA testing before we deploy to production -->
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots

<!-- If this is a UI change, please add screenshots of your change in the table below -->

| Before      | After       |
| ----------- | ----------- |
| 
![no-autoscale-plot](https://github.com/chihacknight/ghost-buses-frontend/assets/36621602/9f4d948d-1df8-4b6b-a704-6505bc46076a)
       |  
![autoscaled-plot](https://github.com/chihacknight/ghost-buses-frontend/assets/36621602/e0622051-d9ce-43f3-84c4-561936558c32)
      |
