### PR TITLE
Add tooltip labels for social icons on hover

### DIFF
--- a/src/components/Socials.js
+++ b/src/components/Socials.js
@@ -6,6 +6,7 @@ export default function Socials() {
       <a
         href="https://twitter.com/ghostbuses"
         aria-label="Ghost Buses Twitter link"
+        title="Twitter"
       >
         <div className="social-icon twitter">
           <i className="fa-brands fa-twitter"></i>
@@ -14,6 +15,7 @@ export default function Socials() {
       <a
         href="https://github.com/chihacknight/chn-ghost-buses"
         aria-label="Ghost Buses GitHub link"
+        title="GitHub"
       >
         <div className="social-icon github">
           <i className="fa-brands fa-github"></i>
@@ -22,6 +24,7 @@ export default function Socials() {
       <a
         href="https://chihacknight.org/"
         aria-label="Chi Hack Night website link"
+        title="Chi Hack Night"
       >
         <div className="social-icon chn">
           <svg


### PR DESCRIPTION
Added the `title` attribute to each `<a>` tag containing appropriate labels to display tooltips when users hover over the social icons. This improvement enhances user experience by providing clear indications of the purpose of each icon.

Before-
![image](https://github.com/chihacknight/ghost-buses-frontend/assets/113019104/6597b284-85dc-4fea-9303-4cf11f3aafce)

After-
![image](https://github.com/chihacknight/ghost-buses-frontend/assets/113019104/202e2ae4-7832-4c61-8076-78884585585b)
